### PR TITLE
Fix for change in new captureStackTrace behaviour

### DIFF
--- a/lib/stack-trace.js
+++ b/lib/stack-trace.js
@@ -3,12 +3,12 @@ exports.get = function(belowFn) {
   Error.stackTraceLimit = Infinity;
 
   var dummyObject = {};
-  Error.captureStackTrace(dummyObject, belowFn || exports.get);
 
   var v8Handler = Error.prepareStackTrace;
   Error.prepareStackTrace = function(dummyObject, v8StackTrace) {
     return v8StackTrace;
   };
+  Error.captureStackTrace(dummyObject, belowFn || exports.get);
 
   var v8StackTrace = dummyObject.stack;
   Error.prepareStackTrace = v8Handler;


### PR DESCRIPTION
For the newer v8 versions in node 0.11.x

Also is backwards compatible. There is a failing test, but that was also failing in the same fashion before this patch.
