### PR TITLE
Fix parsing the stack-trace when it contains objects in the method name

### DIFF
--- a/lib/stack-trace.js
+++ b/lib/stack-trace.js
@@ -39,7 +39,7 @@ exports.parse = function(err) {
         });
       }
 
-      var lineMatch = line.match(/at (?:([^\s]+)\s+)?\(?(?:(.+?):(\d+):(\d+)|([^)]+))\)?/);
+      var lineMatch = line.match(/at (?:([^\(]+)\s+)?\(?(?:(.+?):(\d+):(\d+)|([^)]+))\)?/);
       if (!lineMatch) {
         return;
       }

--- a/test/integration/test-parse.js
+++ b/test/integration/test-parse.js
@@ -2,6 +2,19 @@ var common = require('../common');
 var assert = common.assert;
 var stackTrace = require(common.dir.lib + '/stack-trace');
 
+(function testObjectInMethodName() {
+  var err = {};
+  err.stack =
+'Error: Foo\n' +
+'    at [object Object].global.every [as _onTimeout] (/Users/hoitz/develop/test.coffee:36:3)\n' +
+'    at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)\n';
+
+  var trace = stackTrace.parse(err);
+
+  assert.strictEqual(trace[0].getFileName(), "/Users/hoitz/develop/test.coffee");
+  assert.strictEqual(trace[1].getFileName(), "timers.js");
+})();
+
 (function testBasic() {
   var err = new Error('something went wrong');
   var trace = stackTrace.parse(err);


### PR DESCRIPTION
I noticed that I have some stack traces that contain object definitions in the stack trace.

node-stack-trace was not able to handle these properly, so I adjusted the regular expression a bit. I also added another test case to make sure, that these stack traces are properly handled.

The changes do not break the other tests (however, I did comment out the failing test, see issue https://github.com/felixge/node-stack-trace/issues/4, to make sure that the old tests still pass)
