### PR TITLE
Fix parsing the stack-trace when it contains spaces in the file name portion

### DIFF
--- a/lib/stack-trace.js
+++ b/lib/stack-trace.js
@@ -39,7 +39,7 @@ exports.parse = function(err) {
         });
       }
 
-      var lineMatch = line.match(/at (?:(.+)\s+)?\(?(?:(.+?):(\d+):(\d+)|([^)]+))\)?/);
+      var lineMatch = line.match(/at (?:(.+)\s+\()?(?:(.+?):(\d+):(\d+)|([^)]+))\)?/);
       if (!lineMatch) {
         return;
       }


### PR DESCRIPTION

When spaces are present in the stack line's filename portion node-stack-trace returns wrong fileName in the response object during parsing.

For example if stack line is:"at Layer.handle (/home/harish/Apps-dev/api libs/express-mvc/app.js:30:15)"
linematch at stacktrace.js:42 has the value:
[ 'at Layer.handle (/home/harish/Apps-dev/api libs/express-mvc/app.js:30:15)',
  'Layer.handle (/home/harish/Apps-dev/api',
  'libs/express-mvc/app.js',
  '30',
  '15',
  undefined,
  index: 4,
  input: '    at Layer.handle (/home/harish/Apps-dev/api libs/express-mvc/app.js:30:15)' ]

which should be actually:
[ 'at Layer.handle (/home/harish/Apps-dev/api libs/express-mvc/app.js:30:15)',
  'Layer.handle',
  '/home/harish/Apps-dev/api libs/express-mvc/app.js',
  '30',
  '15',
  undefined,
  index: 4,
  input: '    at Layer.handle (/home/harish/Apps-dev/api libs/express-mvc/app.js:30:15)' ]

To fix this I have modified the regex a little bit.

The changes do not break the other tests (however, I did comment out the failing test, see issue #4, to make sure that the old tests still pass)