### PR TITLE
Don't expect column number to always exists

### DIFF
--- a/lib/stack-trace.js
+++ b/lib/stack-trace.js
@@ -39,7 +39,7 @@ exports.parse = function(err) {
         });
       }
 
-      var lineMatch = line.match(/at (?:(.+)\s+\()?(?:(.+?):(\d+):(\d+)|([^)]+))\)?/);
+      var lineMatch = line.match(/at (?:(.+)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/);
       if (!lineMatch) {
         return;
       }

--- a/test/integration/test-parse.js
+++ b/test/integration/test-parse.js
@@ -53,6 +53,19 @@ var stackTrace = require(common.dir.lib + '/stack-trace');
   assert.equal(trace.length, 2);
 })();
 
+(function testTraceWitoutColumnNumbers() {
+  var err = {};
+  err.stack =
+'AssertionError: true == false\n' +
+'    at Test.fn (/Users/felix/code/node-fast-or-slow/test/fast/example/test-example.js:6)\n' +
+'    at Test.run (/Users/felix/code/node-fast-or-slow/lib/test.js:45)';
+
+  var trace = stackTrace.parse(err);
+  assert.strictEqual(trace[0].getFileName(), "/Users/felix/code/node-fast-or-slow/test/fast/example/test-example.js");
+  assert.strictEqual(trace[0].getLineNumber(), 6);
+  assert.strictEqual(trace[0].getColumnNumber(), null);
+})();
+
 (function testCompareRealWithParsedStackTrace() {
   var realTrace, err;
   function TestClass() {


### PR DESCRIPTION
I'm running some node code on apigee which uses [rhino](https://github.com/mozilla/rhino) under the hood as the javascript engine.

Unfortunately Rhino does not include column numbers in their stack traces which currently causes stack trace parsing with this module to fail.

I've filed the following Issues:

- https://github.com/mozilla/rhino/issues/304
- https://github.com/apigee/trireme/issues/153

but I'm not counting on anything happening there.

This PR make the presence of a column number in the stack trace optional to support runtimes that don't output a column number.