### PR TITLE
Adjust node engine requirements to be less restrictive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stack-trace",
-  "version": "1.0.0-pre1",
+  "version": "1.0.0-pre2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stack-trace",
-      "version": "1.0.0-pre1",
+      "version": "1.0.0-pre2",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.14.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "release": "git push && git push --tags && npm publish"
   },
   "engines": {
-    "node": "16"
+    "node": ">=16"
   },
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Felix Geisendörfer <felix@debuggable.com> (http://debuggable.com/)",
   "name": "stack-trace",
   "description": "Get v8 stack traces as an array of CallSite objects.",
-  "version": "1.0.0-pre1",
+  "version": "1.0.0-pre2",
   "homepage": "https://github.com/felixge/node-stack-trace",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This package works just fine on Node v17. As such, the node engine requirement needs to be less restrictive.